### PR TITLE
Allow DomainPool.generate sequence() to take as input old sequence and mutate it #21

### DIFF
--- a/dsd/constraints.py
+++ b/dsd/constraints.py
@@ -680,7 +680,7 @@ class DomainPool(JSONSerializable):
                 steps = np.random.choice(hamming_distances, p=hamming_probabilities)
                 adjacency_list = self.find_sequence_neighbors(steps, previous_sequence)
             sequence = np.random.choice(adjacency_list)
-            swap_idx = self._sequences.index(previous_sequence)
+            swap_idx = self._sequences.index(sequence)
             # swaps positions of sequence used and the current indexed position so that all
             # sequences after self._idx are unused
             self._sequences[self._idx], self._sequences[swap_idx] = self._sequences[swap_idx], \

--- a/dsd/constraints.py
+++ b/dsd/constraints.py
@@ -602,7 +602,7 @@ class DomainPool(JSONSerializable):
         """
         return all(constraint(sequence) for constraint in self.sequence_constraints)
 
-    def generate_sequence(self, rng: np.random.Generator) -> str:
+    def generate_sequence(self, rng: np.random.Generator, previous_sequence: Optional[str] = None) -> str:
         """
         Returns a DNA sequence of given length satisfying :py:data:`DomainPool.numpy_constraints` and
         :py:data:`DomainPool.sequence_constraints`
@@ -616,6 +616,9 @@ class DomainPool(JSONSerializable):
 
         :param rng:
             numpy random number generator to use. To use a default, pass :py:data:`np.default_rng`.
+        :param previous_sequence:
+            previously generated sequence to be replaced by a new sequence; optional if no previous
+            sequence exists.
         :return:
             DNA sequence of given length satisfying :py:data:`DomainPool.numpy_constraints` and
             :py:data:`DomainPool.sequence_constraints`

--- a/dsd/constraints.py
+++ b/dsd/constraints.py
@@ -666,11 +666,8 @@ class DomainPool(JSONSerializable):
                 logger.debug(f'accepting domain sequence {sequence}; passed all sequence constraints')
         else:
             # takes neighbor to previous sequence; difference in bases randomly chosen
-            hamming_distances = []
-            hamming_probabilities = []
-            for key, val in self.hamming_probability.items(): # make lists for np.random.choice
-                hamming_distances.append(key)
-                hamming_probabilities.append(val)
+            hamming_distances = list(self.hamming_probability.keys())
+            hamming_probabilities = list(self.hamming_probability.values())
             # chooses random number of bases to be changed (steps)
             steps = np.random.choice(hamming_distances, p=hamming_probabilities) # seed?
             neighbors = self.find_steps_distance_sequences(steps, previous_sequence)

--- a/dsd/constraints.py
+++ b/dsd/constraints.py
@@ -576,7 +576,7 @@ class DomainPool(JSONSerializable):
 
     _idx: int = field(compare=False, hash=False, default=0, repr=False)
 
-    find_neighbors_bool: bool = False
+    replace_with_close_sequences: bool = False
 
     hamming_probability: Dict[int, float] = field(default_factory=dict)
     """
@@ -622,13 +622,13 @@ class DomainPool(JSONSerializable):
         Makes a list of sequences some Hamming distance away from the previous sequence.
         The sequence that replaces the previous sequence will be randomly chosen from this list.
         """
-        neighbors_list= []
+        neighbors = []
         for sequence in self._sequences[self._idx:]:
             # counts number of differences between previous sequence and remaining unused sequences
             differences = sum(1 for base1, base2 in zip(previous_sequence, sequence) if base1 != base2)
             if differences == steps:
-                neighbors_list.append(sequence)
-        return neighbors_list
+                neighbors.append(sequence)
+        return neighbors
 
     def generate_sequence(self, rng: np.random.Generator, previous_sequence: Optional[str] = None) -> str:
         """
@@ -656,7 +656,7 @@ class DomainPool(JSONSerializable):
             :py:data:`DomainPool.sequence_constraints`
         """
         log_debug_sequence_constraints_accepted = False
-        if not self.find_neighbors_bool or not previous_sequence:
+        if not self.replace_with_close_sequences or not previous_sequence:
             # takes a completely random sequence from domain pool
             sequence = self._get_next_sequence_satisfying_numpy_constraints(rng)
             while not self.satisfies_sequence_constraints(sequence):
@@ -673,13 +673,13 @@ class DomainPool(JSONSerializable):
                 hamming_probabilities.append(val)
             # chooses random number of bases to be changed (steps)
             steps = np.random.choice(hamming_distances, p=hamming_probabilities) # seed?
-            neighbors_list = self.find_steps_distance_sequences(steps, previous_sequence)
-            while len(neighbors_list) == 0:
+            neighbors = self.find_steps_distance_sequences(steps, previous_sequence)
+            while len(neighbors) == 0:
                 # changes value of steps until a neighbor of the previous_sequence is found
                 # print(f'No neighbors found {steps} away, choosing different step')
                 steps = np.random.choice(hamming_distances, p=hamming_probabilities)
-                neighbors_list = self.find_steps_distance_sequences(steps, previous_sequence)
-            sequence = np.random.choice(neighbors_list)
+                neighbors = self.find_steps_distance_sequences(steps, previous_sequence)
+            sequence = np.random.choice(neighbors)
             swap_idx = self._sequences.index(sequence)
             # swaps positions of sequence used and the current indexed position so that all
             # sequences after self._idx are unused

--- a/dsd/search.py
+++ b/dsd/search.py
@@ -1263,7 +1263,7 @@ class SearchParameters:
 
     restart: bool = False
     """
-    If this function was previous called and placed files in `out_directory`, calling with this
+    If this function was previously called and placed files in `out_directory`, calling with this
     parameter True will re-start the search at that point.
     """
 
@@ -1553,7 +1553,7 @@ def _reassign_domains(domains_opt: List[Domain], weights_opt: List[float], max_d
         # set sequence of domain_changed to random new sequence from its DomainPool
         assert domain not in original_sequences
         original_sequences[domain] = domain.sequence
-        domain.sequence = domain.pool.generate_sequence(rng)
+        domain.sequence = domain.pool.generate_sequence(rng, domain.sequence)
 
     dependent_domains = [domain for domain in domains_changed if domain.dependent]
     for domain in dependent_domains:
@@ -1853,6 +1853,7 @@ def assign_sequences_to_domains_randomly_from_pools(design: Design,
     for domain in independent_domains:
         skip_fixed_msg = skip_nonfixed_msg = None
         if domain.has_sequence():
+            # TODO check var names (appear swapped)
             skip_fixed_msg = f'Skipping assignment of DNA sequence to domain {domain.name}. ' \
                              f'That domain has a NON-FIXED sequence {domain.sequence}, ' \
                              f'which the search will attempt to replace.'
@@ -1860,7 +1861,7 @@ def assign_sequences_to_domains_randomly_from_pools(design: Design,
                                 f'That domain has a FIXED sequence {domain.sequence}.'
         if overwrite_existing_sequences:
             if not domain.fixed:
-                domain.sequence = domain.pool.generate_sequence(rng)
+                domain.sequence = domain.pool.generate_sequence(rng, domain.sequence)
                 assert len(domain.sequence) == domain.pool.length
             else:
                 logger.info(skip_fixed_msg)

--- a/examples/hamming_dist_test.py
+++ b/examples/hamming_dist_test.py
@@ -1,0 +1,34 @@
+import dsd.search as ds  # type: ignore
+import dsd.constraints as dc  # type: ignore
+import dsd.vienna_nupack as dv  # type: ignore
+
+
+domain_length = 15
+# energy_constraint = dc.NearestNeighborEnergyConstraint(low_energy=-9.2, high_energy=-7)
+numpy_constraints = [# energy_constraint,
+                     dc.RunsOfBasesConstraint(['C', 'G'], 4),
+                     dc.RunsOfBasesConstraint(['A', 'T'], 4)
+                     ]
+domain_pool = dc.DomainPool(f'length-{domain_length} domains', domain_length,
+                                numpy_constraints=numpy_constraints, find_neighbor_sequences=True)
+
+def main():
+    random_seed = 0
+    strands = [dc.Strand([f'{i}' for i in range(1,50)])]
+    for strand in strands:
+        for domain in strand.domains:
+            domain.pool = domain_pool
+    params = ds.SearchParameters(out_directory='output/hamming_dist_test',
+                                 # weigh_violations_equally=True
+                                 report_only_violations=False,
+                                 random_seed=random_seed,
+                                 max_iterations=None)
+    params.force_overwrite = True # directly deletes output folder contents w/o user input
+    # params.report_delay = 0.0
+    design = dc.Design(strands, constraints=[dc.nupack_4_strand_secondary_structure_constraint(
+        threshold=-1.5, temperature=52, short_description='StrandSS', threaded=False)])
+    ds.search_for_dna_sequences(design, params)
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
- created an adjacency list (since the step isn't necessarily 1, I decided to call the variable adjacency_list instead of hamming_graph) to store previously used sequences and their neighbors some step away; it doesn't seem necessary to store the step number or even the neighbors, but no code was added to remove the neighbors in case it would be useful 
- used random.choice() to choose neighbors of the sequence to be replaced; not sure if a random seed should be used for reproducibility? 