### PR TITLE
Fixes #139; make PyPI package that does not include NUPACK or ViennaRNA

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -5,19 +5,25 @@ on: pull_request
 jobs:
   docs:
     runs-on: ubuntu-latest
+    container:
+      image: unhumbleben/nupack:latest
     steps:
     - uses: actions/checkout@v2.3.4
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-          python-version: '3.x'
+          python-version: '3.9'
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip
+    - name: Install NUPACK
+      run: |
+        python -m pip install -U nupack -f /nupack/package
     # got from here: https://github.com/marketplace/actions/python-dependency-installation
     # should install dependencies in requirements.txt
     - name: Install Python dependencies
       uses: py-actions/py-dependency-install@v2
     - name: Install Sphinx
       run: |
-        python -m pip install --upgrade pip
         pip install sphinx sphinx_rtd_theme
     - name: Move to docs folder and build
       run: |

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -9,6 +9,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    container:
+      image: unhumbleben/nupack:latest
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
@@ -19,9 +21,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip
+    - name: Install NUPACK
+      run: |
+        python -m pip install -U nupack -f /nupack/package
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with unittest
       run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include LICENSE

--- a/dsd/__version__.py
+++ b/dsd/__version__.py
@@ -1,0 +1,1 @@
+version = '0.0.1'  # version line; WARNING: do not remove or change this line or comment

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pathos
 scadnano
 xlwt
 xlrd
+nupack

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,48 @@
+from setuptools import setup
+from os import path
+
+
+# this is ugly, but appears to be standard practice:
+# https://stackoverflow.com/questions/17583443/what-is-the-correct-way-to-share-package-version-with-setup-py-and-the-package/17626524#17626524
+def extract_version(filename: str):
+    with open(filename) as f:
+        lines = f.readlines()
+    version_comment = '# version line; WARNING: do not remove or change this line or comment'
+    for line in lines:
+        if version_comment in line:
+            idx = line.index(version_comment)
+            line_prefix = line[:idx]
+            parts = line_prefix.split('=')
+            parts = [part.strip() for part in parts]
+            version_str = parts[-1]
+            version_str = version_str.replace('"', '')
+            version_str = version_str.replace("'", '')
+            version_str = version_str.strip()
+            return version_str
+    raise AssertionError(f'could not find version in {filename}')
+
+
+version = extract_version('dsd/__version__.py')
+print(f'dsd version = {version}')
+
+with open("requirements.txt") as fp:
+    install_requires = fp.read().strip().split("\n")
+
+# read the contents of your README file
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(name='dsd',
+      packages=['dsd'],
+      version=version,
+      license='MIT',
+      description="dsd stands for \"DNA sequence designer\". Enables one to specify constraints on a DNA nanostructure made from synthetic DNA and then attempts to find concrete DNA sequences that satisfy the constraints.",
+      author="David Doty",
+      author_email="doty@ucdavis.edu",
+      url="https://github.com/UC-Davis-molecular-computing/dsd",
+      long_description=long_description,
+      long_description_content_type='text/markdown; variant=GFM',
+      python_requires='>=3.7',
+      install_requires=install_requires
+      )


### PR DESCRIPTION
## Description
Add setuptools files to make dsd a PyPI package

## Related Issue
#139

## How Has This Been Tested?

Tested package deployment and installation

### Deployment on TestPyPI:
```
python3.8 setup.py sdist
twine upload --repository testpypi dist/*
```
Result: https://test.pypi.org/project/dsd/0.0.1.1/ (note that version 0.0.1.1 is a version used for test, but in the real package, we will use version 0.0.1)

### Installation:
Created a new virtual environment and ran the following command which mocks `pip install dsd`
```
pip3.8 install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple --no-cache-dir  dsd==0.0.1.1
```
Without nupack, an error occurs:
```
ERROR: Could not find a version that satisfies the requirement nupack (from dsd) (from versions: none)
ERROR: No matching distribution found for nupack
```
After [installing nupack](https://docs.nupack.org/start/#maclinux-installation), rerunning the pip install command results in success. Also ran `import dsd` on python shell and verified no errors occur.

## Next Steps

Rather than uploading to PyPI manually, I suggest waiting until I set up the release workflow, which will take care of publishing to PyPI (See #138)
